### PR TITLE
CoCに従い関係キーを削除

### DIFF
--- a/app/models/imagelog.rb
+++ b/app/models/imagelog.rb
@@ -1,4 +1,4 @@
 class Imagelog < ApplicationRecord
-	belongs_to :user ,class_name: "User", foreign_key: "user_id"
-	belongs_to :room ,class_name: "Room", foreign_key: "room_id"
+	belongs_to :user ,class_name: "User"
+	belongs_to :room ,class_name: "Room"
 end

--- a/app/models/room.rb
+++ b/app/models/room.rb
@@ -1,5 +1,5 @@
 class Room < ApplicationRecord
-	belongs_to :user ,class_name: "User", foreign_key: "create_user_id"
+	belongs_to :user ,class_name: "User"
 	has_many :textlogs ,dependent: :destroy
 	has_many :imagelogs ,dependent: :destroy
 end

--- a/app/models/textlog.rb
+++ b/app/models/textlog.rb
@@ -1,4 +1,4 @@
 class Textlog < ApplicationRecord
-	belongs_to :user ,class_name: "User", foreign_key: "user_id"
-	belongs_to :room ,class_name: "Room", foreign_key: "room_id"
+	belongs_to :user ,class_name: "User"
+	belongs_to :room ,class_name: "Room"
 end


### PR DESCRIPTION
# Convention over Configuration
設定より規約

Rails開発者の思想に沿って開発を行うことでコード量を減らす考え
例:DBの命名も規約に従っていればモデルの連携も非常に楽になる。

## メリット
誰が作っても大体同じ場所に決まった名前のファイルが置かれて似たようなコードになるので、メンテナンスがとてもスムーズ。 

## デメリット
学習コストが掛かる。 

[参考](https://postd.cc/rails-doctrine/#convention-over-configuration
Fixes #)